### PR TITLE
Updated dependencies and support latest KenLM version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "decode"
 libm = "~0.2"
 pdqselect = "~0.1"
 thiserror = "1.0"
-ordered-float = "2.10"
+ordered-float = "4.2"
 
 [dependencies.dhat]
 optional = true
@@ -33,7 +33,7 @@ path = "ctclib-kenlm-sys"
 version = "0.1"
 
 [dev-dependencies]
-criterion = "0.3.6"
+criterion = "0.5.1"
 
 [features]
 default = ["kenlm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 edition = "2021"
 name = "ctclib-pp"
 version = "0.2.0"
-authors = ["Naomichi Agata <agatan039@gmail.com>", "Julien Abadji <aulien.jbadji@gmail.com>"]
+authors = [
+    "Naomichi Agata <agatan039@gmail.com>",
+    "Julien Abadji <aulien.jbadji@gmail.com>",
+]
 license = "MIT"
 repository = "https://github.com/Uinelj/ctclib"
 description = "A collection of utilities related to CTC, with the goal of being fast and highly flexible, with perplexity scores for KenLMs models"
@@ -18,11 +21,11 @@ name = "decode"
 libm = "~0.2"
 pdqselect = "~0.1"
 thiserror = "1.0"
-ordered-float = "2.0"
+ordered-float = "2.10"
 
 [dependencies.dhat]
 optional = true
-version = "0.3.0"
+version = "0.3.2"
 
 [dependencies.ctclib-kenlm-sys]
 optional = true
@@ -30,7 +33,7 @@ path = "ctclib-kenlm-sys"
 version = "0.1"
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = "0.3.6"
 
 [features]
 default = ["kenlm"]

--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -1,7 +1,7 @@
 use std::io::BufRead;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ctclib::{BeamSearchDecoder, BeamSearchDecoderOptions, Decoder, GreedyDecoder, ZeroLM};
+use ctclib_pp::{BeamSearchDecoder, BeamSearchDecoderOptions, Decoder, GreedyDecoder, ZeroLM};
 
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]
@@ -48,7 +48,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 fn criterion_benchmark_kenlm(c: &mut Criterion) {
     use std::path::Path;
 
-    use ctclib::{Dict, KenLM};
+    use ctclib_pp::{Dict, KenLM};
 
     let (steps, n_vocab, data) = load_logits();
     let blank = (n_vocab - 1) as i32;

--- a/ctclib-kenlm-sys/Cargo.toml
+++ b/ctclib-kenlm-sys/Cargo.toml
@@ -13,6 +13,6 @@ readme = "README.md"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.59.2"
-cc = "1.0.72"
-cmake = "0.1.48"
+bindgen = "0.69.1"
+cc = "1.0.83"
+cmake = "0.1.50"

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Borrow,
     collections::HashMap,
     fs::File,
     io::{BufRead, BufReader, Read},
@@ -88,7 +87,7 @@ impl Dict {
     }
 
     pub fn index(&self, entry: &str) -> Result<i32, DictError> {
-        match self.entry2idx.get(entry.borrow()) {
+        match self.entry2idx.get(entry) {
             Some(&idx) => Ok(idx),
             None => Err(DictError::MissingEntry(entry.to_owned())),
         }

--- a/src/lm/kenlm.rs
+++ b/src/lm/kenlm.rs
@@ -113,7 +113,7 @@ impl<'a> Vocabulary<'a> {
             ctclib_kenlm_sys::lm_base_Vocabulary_Index(
                 self.0,
                 x.as_ptr() as *const _,
-                x.as_bytes().len() as u64,
+                x.as_bytes().len(),
             )
         }
     }

--- a/tests/decoder_test.rs
+++ b/tests/decoder_test.rs
@@ -1,6 +1,6 @@
 use std::{io::BufRead, path::Path};
 
-use ctclib::{
+use ctclib_pp::{
     BeamSearchDecoder, BeamSearchDecoderOptions, Decoder, Dict, GreedyDecoder, KenLM, ZeroLM,
 };
 

--- a/tests/kenlm_test.rs
+++ b/tests/kenlm_test.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, path::Path};
 
-use ctclib::{Dict, KenLM, LM};
+use ctclib_pp::{Dict, KenLM, LM};
 
 #[test]
 fn kenlm_model_works() {


### PR DESCRIPTION
I updated some dependencies and made some small changes so that this compiles with the latest version of clang, the latest version of KenLM, and so that it also compiles for ARM Macs.

For reference with the following clang version:
```
clang version 16.0.6
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /p/software/cluster/stages/2024/software/Clang/16.0.6-GCCcore-12.3.0/bin
```

I was getting the following error:
```
  --- stderr
  CMake Warning:
    Manually-specified variables were not used by the project:

      CMAKE_ASM_COMPILER
      CMAKE_ASM_FLAGS


  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/trie_sort.cc:1:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/trie_sort.hh:31:34: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     31 | class EntryCompare : public std::binary_function<const void*, const void*, bool> {
        |                                  ^~~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/fake_ostream.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/string_stream.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/exception.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/file.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/trie_sort.hh:9:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/trie_sort.cc:13:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/sized_iterator.hh:130:86: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    130 | template <class Delegate, class Proxy = SizedProxy> class SizedCompare : public std::binary_function<const Proxy &, const Proxy &, bool> {
        |                                                                                      ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/sized_iterator.hh:157:71: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    157 | template <class Delegate, unsigned Size> class JustPODDelegate : std::binary_function<const JustPOD<Size> &, const JustPOD<Size> &, bool> {
        |                                                                       ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/vocab.cc:11:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/joint_sort.hh:104:68: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    104 | template <class Proxy, class Less> class LessWrapper : public std::binary_function<const typename Proxy::value_type &, const typename Proxy::value_type &, bool> {
        |                                                                    ^~~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/enumerate_vocab.hh:5,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/vocab.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/vocab.cc:1:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/arpa_io.hh:9,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/arpa_io.cc:1:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/tokenize_piece.hh:99:77: warning: ‘template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator’ is deprecated [-Wdeprecated-declarations]
     99 | template <class Find, bool SkipEmpty = false> class TokenIter : public std::iterator<std::forward_iterator_tag, const StringPiece, std::ptrdiff_t, const StringPiece *, const StringPiece &> {
        |                                                                             ^~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:45,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/fake_ostream.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_stream.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/exception.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../lm_exception.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../read_arpa.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/arpa_io.hh:5:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_iterator_base_types.h:127:34: note: declared here
    127 |     struct _GLIBCXX17_DEPRECATED iterator
        |                                  ^~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/search_trie.cc:11:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/trie_sort.hh:31:34: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     31 | class EntryCompare : public std::binary_function<const void*, const void*, bool> {
        |                                  ^~~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/fake_ostream.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/string_stream.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/exception.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/lm_exception.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/config.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/search_trie.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/search_trie.cc:2:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/search_trie.cc:19:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/sized_iterator.hh:130:86: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    130 | template <class Delegate, class Proxy = SizedProxy> class SizedCompare : public std::binary_function<const Proxy &, const Proxy &, bool> {
        |                                                                                      ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/sized_iterator.hh:157:71: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    157 | template <class Delegate, unsigned Size> class JustPODDelegate : std::binary_function<const JustPOD<Size> &, const JustPOD<Size> &, bool> {
        |                                                                       ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/vocab.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/vocab.cc:1:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/multi_intersection.hh:14:61: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     14 | template <class Range> struct RangeLessBySize : public std::binary_function<const Range &, const Range &, bool> {
        |                                                             ^~~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/stdexcept:39,
                   from /p/software/cluster/stages/2024/software/Boost/1.82.0-GCCcore-12.3.0/include/boost/optional/bad_optional_access.hpp:15,
                   from /p/software/cluster/stages/2024/software/Boost/1.82.0-GCCcore-12.3.0/include/boost/optional/optional.hpp:34,
                   from /p/software/cluster/stages/2024/software/Boost/1.82.0-GCCcore-12.3.0/include/boost/optional.hpp:15,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/multi_intersection.hh:4:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/vocab.hh:8:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_piece_hash.hh:23:48: warning: ‘template<class _Arg, class _Result> struct std::unary_function’ is deprecated [-Wdeprecated-declarations]
     23 | struct StringPieceCompatibleHash : public std::unary_function<const StringPiece &, size_t> {
        |                                                ^~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:117:12: note: declared here
    117 |     struct unary_function
        |            ^~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_piece_hash.hh:29:50: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     29 | struct StringPieceCompatibleEquals : public std::binary_function<const StringPiece &, const std::string &, bool> {
        |                                                  ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/vocab.hh:9:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/tokenize_piece.hh:99:77: warning: ‘template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator’ is deprecated [-Wdeprecated-declarations]
     99 | template <class Find, bool SkipEmpty = false> class TokenIter : public std::iterator<std::forward_iterator_tag, const StringPiece, std::ptrdiff_t, const StringPiece *, const StringPiece &> {
        |                                                                             ^~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:45:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_iterator_base_types.h:127:34: note: declared here
    127 |     struct _GLIBCXX17_DEPRECATED iterator
        |                                  ^~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/phrase.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/phrase.cc:1:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/tokenize_piece.hh:99:77: warning: ‘template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator’ is deprecated [-Wdeprecated-declarations]
     99 | template <class Find, bool SkipEmpty = false> class TokenIter : public std::iterator<std::forward_iterator_tag, const StringPiece, std::ptrdiff_t, const StringPiece *, const StringPiece &> {
        |                                                                             ^~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:45,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/phrase.hh:5:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_iterator_base_types.h:127:34: note: declared here
    127 |     struct _GLIBCXX17_DEPRECATED iterator
        |                                  ^~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/common/model_buffer.cc:3:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/common/compare.hh:15:55: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     15 | template <class Child> class Comparator : public std::binary_function<const void *, const void *, bool> {
        |                                                       ^~~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/common/../../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/common/../../util/fake_ostream.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/common/../../util/string_stream.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/common/../../util/exception.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/common/../../util/file.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/common/model_buffer.hh:8,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/common/model_buffer.cc:1:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/common/compare.hh:173:69: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    173 | template <class Range> struct SuffixLexicographicLess : public std::binary_function<const Range, const Range, bool> {
        |                                                                     ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/phrase.cc:107:33: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    107 | struct ArcGreater : public std::binary_function<const Arc *, const Arc *, bool> {
        |                                 ^~~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/fragment_main.cc:4:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/tokenize_piece.hh:99:77: warning: ‘template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator’ is deprecated [-Wdeprecated-declarations]
     99 | template <class Find, bool SkipEmpty = false> class TokenIter : public std::iterator<std::forward_iterator_tag, const StringPiece, std::ptrdiff_t, const StringPiece *, const StringPiece &> {
        |                                                                             ^~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:45,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/fake_ostream.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/string_stream.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/../util/exception.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/lm_exception.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/config.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/binary_format.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/fragment_main.cc:1:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_iterator_base_types.h:127:34: note: declared here
    127 |     struct _GLIBCXX17_DEPRECATED iterator
        |                                  ^~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/phrase_table_vocab_main.cc:6:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_piece_hash.hh:23:48: warning: ‘template<class _Arg, class _Result> struct std::unary_function’ is deprecated [-Wdeprecated-declarations]
     23 | struct StringPieceCompatibleHash : public std::unary_function<const StringPiece &, size_t> {
        |                                                ^~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/fake_ostream.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/file_stream.hh:7,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/phrase_table_vocab_main.cc:1:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:117:12: note: declared here
    117 |     struct unary_function
        |            ^~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_piece_hash.hh:29:50: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     29 | struct StringPieceCompatibleEquals : public std::binary_function<const StringPiece &, const std::string &, bool> {
        |                                                  ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/phrase_table_vocab_main.cc:7:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/tokenize_piece.hh:99:77: warning: ‘template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator’ is deprecated [-Wdeprecated-declarations]
     99 | template <class Find, bool SkipEmpty = false> class TokenIter : public std::iterator<std::forward_iterator_tag, const StringPiece, std::ptrdiff_t, const StringPiece *, const StringPiece &> {
        |                                                                             ^~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:45:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_iterator_base_types.h:127:34: note: declared here
    127 |     struct _GLIBCXX17_DEPRECATED iterator
        |                                  ^~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/combine_counts.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/pipeline.cc:4:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../common/compare.hh:15:55: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     15 | template <class Child> class Comparator : public std::binary_function<const void *, const void *, bool> {
        |                                                       ^~~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/fake_ostream.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/string_stream.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/exception.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../lm_exception.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/adjust_counts.hh:5,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/pipeline.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/pipeline.cc:1:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../common/compare.hh:173:69: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    173 | template <class Range> struct SuffixLexicographicLess : public std::binary_function<const Range, const Range, bool> {
        |                                                                     ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/arpa_io.hh:9,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/filter_main.cc:1:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/tokenize_piece.hh:99:77: warning: ‘template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator’ is deprecated [-Wdeprecated-declarations]
     99 | template <class Find, bool SkipEmpty = false> class TokenIter : public std::iterator<std::forward_iterator_tag, const StringPiece, std::ptrdiff_t, const StringPiece *, const StringPiece &> {
        |                                                                             ^~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:45,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/fake_ostream.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_stream.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/exception.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../lm_exception.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../read_arpa.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/arpa_io.hh:5:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_iterator_base_types.h:127:34: note: declared here
    127 |     struct _GLIBCXX17_DEPRECATED iterator
        |                                  ^~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/sort.hh:29,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/combine_counts.hh:8:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/../sized_iterator.hh:130:86: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    130 | template <class Delegate, class Proxy = SizedProxy> class SizedCompare : public std::binary_function<const Proxy &, const Proxy &, bool> {
        |                                                                                      ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/../sized_iterator.hh:157:71: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    157 | template <class Delegate, unsigned Size> class JustPODDelegate : std::binary_function<const JustPOD<Size> &, const JustPOD<Size> &, bool> {
        |                                                                       ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/interpolate.cc:5:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../common/compare.hh:15:55: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     15 | template <class Child> class Comparator : public std::binary_function<const void *, const void *, bool> {
        |                                                       ^~~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/../string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/../fake_ostream.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/../string_stream.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/../exception.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/../scoped.hh:5,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/../fixed_array.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/multi_stream.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/interpolate.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/interpolate.cc:1:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../common/compare.hh:173:69: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    173 | template <class Range> struct SuffixLexicographicLess : public std::binary_function<const Range, const Range, bool> {
        |                                                                     ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/sort.hh:203:33: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    203 |     class Greater : public std::binary_function<const Entry &, const Entry &, bool> {
        |                                 ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/corpus_count.cc:15:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/tokenize_piece.hh:99:77: warning: ‘template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator’ is deprecated [-Wdeprecated-declarations]
     99 | template <class Find, bool SkipEmpty = false> class TokenIter : public std::iterator<std::forward_iterator_tag, const StringPiece, std::ptrdiff_t, const StringPiece *, const StringPiece &> {
        |                                                                             ^~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:45,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/locale_classes.h:40,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/ios_base.h:41,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ios:42,
                   from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/ostream:38,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/string_piece.hh:55,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/fake_ostream.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/string_stream.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/exception.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../lm_exception.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/corpus_count.hh:4,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/corpus_count.cc:1:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_iterator_base_types.h:127:34: note: declared here
    127 |     struct _GLIBCXX17_DEPRECATED iterator
        |                                  ^~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/corpus_count.cc:25:32: warning: ‘template<class _Arg, class _Result> struct std::unary_function’ is deprecated [-Wdeprecated-declarations]
     25 | class DedupeHash : public std::unary_function<const WordIndex *, bool> {
        |                                ^~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:117:12: note: declared here
    117 |     struct unary_function
        |            ^~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/corpus_count.cc:37:34: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     37 | class DedupeEquals : public std::binary_function<const WordIndex *, const WordIndex *, bool> {
        |                                  ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/vocab.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/filter_main.cc:7:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/multi_intersection.hh:14:61: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     14 | template <class Range> struct RangeLessBySize : public std::binary_function<const Range &, const Range &, bool> {
        |                                                             ^~~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/string:48:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/vocab.hh:8:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_piece_hash.hh:23:48: warning: ‘template<class _Arg, class _Result> struct std::unary_function’ is deprecated [-Wdeprecated-declarations]
     23 | struct StringPieceCompatibleHash : public std::unary_function<const StringPiece &, size_t> {
        |                                                ^~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:117:12: note: declared here
    117 |     struct unary_function
        |            ^~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/filter/../../util/string_piece_hash.hh:29:50: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     29 | struct StringPieceCompatibleEquals : public std::binary_function<const StringPiece &, const std::string &, bool> {
        |                                                  ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/combine_counts.hh:6,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/count_ngrams_main.cc:1:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../common/compare.hh:15:55: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
     15 | template <class Child> class Comparator : public std::binary_function<const void *, const void *, bool> {
        |                                                       ^~~~~~~~~~~~~~~
  In file included from /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/functional:49,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../common/compare.hh:7:
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../common/compare.hh:173:69: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    173 | template <class Range> struct SuffixLexicographicLess : public std::binary_function<const Range, const Range, bool> {
        |                                                                     ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  In file included from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/sort.hh:29,
                   from /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/combine_counts.hh:8:
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/../sized_iterator.hh:130:86: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    130 | template <class Delegate, class Proxy = SizedProxy> class SizedCompare : public std::binary_function<const Proxy &, const Proxy &, bool> {
        |                                                                                      ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/../sized_iterator.hh:157:71: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    157 | template <class Delegate, unsigned Size> class JustPODDelegate : std::binary_function<const JustPOD<Size> &, const JustPOD<Size> &, bool> {
        |                                                                       ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  /path/code/github.com/Uinelj/ctclib/target/release/build/ctclib-kenlm-sys-82846a3719a618e1/out/kenlm/lm/builder/../../util/stream/sort.hh:203:33: warning: ‘template<class _Arg1, class _Arg2, class _Result> struct std::binary_function’ is deprecated [-Wdeprecated-declarations]
    203 |     class Greater : public std::binary_function<const Entry &, const Entry &, bool> {
        |                                 ^~~~~~~~~~~~~~~
  /p/software/cluster/stages/2024/software/GCCcore/12.3.0/include/c++/12.3.0/bits/stl_function.h:131:12: note: declared here
    131 |     struct binary_function
        |            ^~~~~~~~~~~~~~~
  thread 'main' panicked at /path/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bindgen-0.59.2/src/ir/context.rs:878:9:
  "std_basic_string_(unnamed_enum_at_/p/software/cluster/stages/2024/software/GCCcore/12_3_0/lib/gcc/x86_64-pc-linux-gnu/12_3_0/__/__/__/__/include/c++/12_3_0/bits/basic_string_h_213_7)" is not a valid Ident
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ```
 
 The error did not appear with clang version:
 ```
clang version 13.0.1
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /p/software/cluster/stages/2023/software/Clang/13.0.1-GCCcore-11.3.0/bin
```

I can confirm that the code in this PR compiles with both the old and the new clang version. It also compiles for MacOS ARM with clang version:
```
Homebrew clang version 17.0.4
Target: arm64-apple-darwin23.2.0
Thread model: posix
InstalledDir: /opt/homebrew/opt/llvm/bin
```